### PR TITLE
Fixing error in reading yml vocabulary (descriptors)

### DIFF
--- a/src/DescManip.cpp
+++ b/src/DescManip.cpp
@@ -178,16 +178,18 @@ void DescManip::fromString(cv::Mat &a, const std::string &s)
     }
     else{
         int type,cols;
-        stringstream ss(s);
+        stringstream ss(s.substr(ss_aux.find("dbw3")+5,s.size()-5));
         ss >>type>>cols;
         a.create(1,  cols, type);
         if(type==CV_8UC1){
+            std::cout<<"A\n";
             unsigned char *p = a.ptr<unsigned char>();
             int n;
             for(int i = 0; i <  a.cols; ++i, ++p)
                 if ( ss >> n) *p = (unsigned char)n;
         }
         else{
+            std::cout<<"B\n";
             float *p = a.ptr<float>();
             for(int i = 0; i <  a.cols; ++i, ++p)
                 if ( !(ss >> *p))cerr<<"Error reading. Unexpected EOF. DescManip::fromString"<<endl;

--- a/src/DescManip.cpp
+++ b/src/DescManip.cpp
@@ -182,14 +182,12 @@ void DescManip::fromString(cv::Mat &a, const std::string &s)
         ss >>type>>cols;
         a.create(1,  cols, type);
         if(type==CV_8UC1){
-            std::cout<<"A\n";
             unsigned char *p = a.ptr<unsigned char>();
             int n;
             for(int i = 0; i <  a.cols; ++i, ++p)
                 if ( ss >> n) *p = (unsigned char)n;
         }
         else{
-            std::cout<<"B\n";
             float *p = a.ptr<float>();
             for(int i = 0; i <  a.cols; ++i, ++p)
                 if ( !(ss >> *p))cerr<<"Error reading. Unexpected EOF. DescManip::fromString"<<endl;


### PR DESCRIPTION
Hi @rmsalinas 

I noticed in the code that when you read the yml vocabulary file in DescManip::fromString you use the initial descriptor string (including "dbw3") to recover the type and number of elements in descriptor:

stringstream ss(s);
ss >>type>>cols;

This was the "dbw3" tag is still at the beginning of the descriptor string causing wrong assignment of both type and cols variables. A simple solution I did was to remove the initial part of the string (up to the space after the "dbw3" tag) and process the string as before.

If I overlooked something and this doesnt make sense I apologize :) 

Klemen