### PR TITLE
Fix incorrect inline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@
 # ----------------------------------------------------------------------------
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 
+set(CMAKE_CXX_STANDARD 11)
+
 PROJECT(DBoW3)
 set(PROJECT_VERSION "0.0.1")
 string(REGEX MATCHALL "[0-9]" PROJECT_VERSION_PARTS "${PROJECT_VERSION}")

--- a/src/Database.h
+++ b/src/Database.h
@@ -90,7 +90,7 @@ public:
    * @param T class inherited from Vocabulary
    * @param voc vocabulary to copy
    */
-  inline void setVocabulary(const Vocabulary &voc);
+  void setVocabulary(const Vocabulary &voc);
   
   /**
    * Sets the vocabulary to use and the direct index parameters, and clears
@@ -108,7 +108,7 @@ public:
    * Returns a pointer to the vocabulary used
    * @return vocabulary
    */
-  inline const Vocabulary* getVocabulary() const;
+  const Vocabulary* getVocabulary() const;
 
   /** 
    * Allocates some memory for the direct and inverted indexes
@@ -150,7 +150,7 @@ public:
   /**
    * Empties the database
    */
-  inline void clear();
+  void clear();
 
   /**
    * Returns the number of entries in the database 


### PR DESCRIPTION
Some declarations in Database.h are with inline but the implementation is not in Database.h. This causes linking error because the compiled libDBoW3.so won't have these symbols while user code cannot get inline implementation, either.