### PR TITLE
Add max iteration times

### DIFF
--- a/src/Vocabulary.cpp
+++ b/src/Vocabulary.cpp
@@ -3,9 +3,11 @@
 #include "quicklz.h"
 #include <sstream>
 #include "timers.h"
+
+const int MAX_ITERATION = 100;
+
 namespace DBoW3{
 // --------------------------------------------------------------------------
-
 
 Vocabulary::Vocabulary
   (int k, int L, WeightingType weighting, ScoringType scoring)
@@ -263,9 +265,11 @@ void Vocabulary::HKmeansStep(NodeId parent_id,
 
         // to check if clusters move after iterations
         std::vector<int> last_association, current_association;
-
-        while(goon)
+	
+	int count = 0;
+        while(goon && count < MAX_ITERATION)
         {
+	    count++;
             // 1. Calculate clusters
 
             if(first_time)


### PR DESCRIPTION
When training with float point descriptors, the K-means step may be not converging. Adding a limitation of max iteration times could solve it.