### PR TITLE
Make compileable with C++17 or later

### DIFF
--- a/src/Vocabulary.cpp
+++ b/src/Vocabulary.cpp
@@ -1177,7 +1177,7 @@ void Vocabulary::save(cv::FileStorage &f,
 
 }
 
-void Vocabulary::toStream(  std::ostream &out_str, bool compressed) const throw(std::exception){
+void Vocabulary::toStream(  std::ostream &out_str, bool compressed) const noexcept(false){
 
     uint64_t sig=88877711233;//magic number describing the file
     out_str.write((char*)&sig,sizeof(sig));
@@ -1257,7 +1257,7 @@ void Vocabulary::toStream(  std::ostream &out_str, bool compressed) const throw(
 }
 
 
-void Vocabulary:: load_fromtxt(const std::string &filename)throw(std::runtime_error){
+void Vocabulary:: load_fromtxt(const std::string &filename)noexcept(false){
 
     std::ifstream ifile(filename);
     if(!ifile)throw std::runtime_error("Vocabulary:: load_fromtxt  Could not open file for reading:"+filename);
@@ -1332,7 +1332,7 @@ void Vocabulary:: load_fromtxt(const std::string &filename)throw(std::runtime_er
            }
        }
 }
-void Vocabulary::fromStream(  std::istream &str )   throw(std::exception){
+void Vocabulary::fromStream(  std::istream &str )   noexcept(false){
 
 
     m_words.clear();

--- a/src/Vocabulary.h
+++ b/src/Vocabulary.h
@@ -299,8 +299,8 @@ public:
    */
   int getDescritorType()const;
   //io to-from a stream
-  void toStream(  std::ostream &str, bool compressed=true) const throw(std::exception);
-  void fromStream(  std::istream &str )   throw(std::exception);
+  void toStream(  std::ostream &str, bool compressed=true) const noexcept(false);
+  void fromStream(  std::istream &str )   noexcept(false);
 
  protected:
 
@@ -435,7 +435,7 @@ protected:
 
    /**Loads from ORBSLAM txt files
     */
-   void load_fromtxt(const std::string &filename)throw(std::runtime_error);
+   void load_fromtxt(const std::string &filename)noexcept(false);
 
 protected:
 


### PR DESCRIPTION
The `Vocabulary.h` and `Vocabulary.cpp` codes contain dynamic exception specifications.
However, this specification was removed in C++17, and the code fails to compile in C++17 or later.
So, by rewriting the corresponding code to `noexcept(false)`, make it explicit that the method may send an exception.