### PR TITLE
fixing centroids override by using cv::mat deep copy

### DIFF
--- a/src/Vocabulary.cpp
+++ b/src/Vocabulary.cpp
@@ -396,14 +396,18 @@ void Vocabulary::HKmeansStep(NodeId parent_id,
 
 void Vocabulary::initiateClusters
   (const std::vector<cv::Mat> &descriptors,
-   std::vector<cv::Mat> &clusters) const
+    std::vector<cv::Mat> &clusters) const
 {
   initiateClustersKMpp(descriptors, clusters);
 }
 
 // --------------------------------------------------------------------------
 
-
+void Vocabulary::createNewCentroid(cv::Mat &feature,std::vector<cv::Mat> &clusters){
+  cv::Mat copy;
+  feature.copyTo(copy);
+  clusters.push_back(copy);
+}
 void Vocabulary::initiateClustersKMpp(
   const std::vector<cv::Mat> &pfeatures,
     std::vector<cv::Mat> &clusters) const
@@ -431,8 +435,7 @@ void Vocabulary::initiateClustersKMpp(
   int ifeature = rand()% pfeatures.size();//DUtils::Random::RandomInt(0, pfeatures.size()-1);
 
   // create first cluster
-  clusters.push_back(pfeatures[ifeature]);
-
+  createNewCentroid(pfeatures[ifeature],clusters);
   // compute the initial distances
    std::vector<double>::iterator dit;
   dit = min_dists.begin();
@@ -477,9 +480,7 @@ void Vocabulary::initiateClustersKMpp(
         ifeature = pfeatures.size()-1;
       else
         ifeature = dit - min_dists.begin();
-
-
-      clusters.push_back(pfeatures[ifeature]);
+      createNewCentroid(pfeatures[ifeature],clusters);
     } // if dist_sum > 0
     else
       break;

--- a/src/Vocabulary.h
+++ b/src/Vocabulary.h
@@ -402,7 +402,12 @@ protected:
    */
   virtual void initiateClusters(const std::vector<cv::Mat> &descriptors,
     std::vector<cv::Mat> &clusters) const;
-  
+    /**
+ * @brief Creates a new centroid by making a deep copy of the input feature and stores it in clusters.
+ * @param feature The input feature to be deep copied and used as a new centroid.
+ * @param clusters A vector of cv::Mat objects representing the existing clusters.
+ */
+  void createNewCentroid(cv::Mat &feature,std::vector<cv::Mat> &clusters);
   /**
    * Creates k clusters from the given descriptor sets by running the
    * initial step of kmeans++


### PR DESCRIPTION
Hi
as part of working and improving orb slam 3, we encountered a bug in assigning new centroids  to the voc tree.

we offer simple and clean solution to this in the following commit.

when creating a new voc tree from around 1 million features in the orbslam3 voc.txt, we found that features which are selected as cluster centers during the k-medians are mutated, meaning the leaves that are supposed to represent those features actually hold the mutated version (cluster centers). for example, in a tree with around 900k leaves, we noticed about 200k were mutated.

this damaged the correctness of the voc tree, since we needed to assign weights to each feature/leaf, using the original voc.txt weights. this means mutated features had no correct weights. after this change, we notice no original feature was mutated.