### PR TITLE
feat: Include extra library BowVector.h

### DIFF
--- a/src/BowVector.h
+++ b/src/BowVector.h
@@ -12,6 +12,9 @@
 
 #include <map>
 #include <vector>
+#include <ostream>
+#include <string>
+#include <cstdint>
 #include "exports.h"
 #if _WIN32
 #include <cstdint>


### PR DESCRIPTION
Dear rmsalinas,

I try to compile DBoW3 in Ubuntu22.04. But some errors occur.
Some basic libraries are missing in src/BowVector.h, so I added them.